### PR TITLE
Skip validation in testing environment

### DIFF
--- a/src/Pages/Actions/DeleteAction.php
+++ b/src/Pages/Actions/DeleteAction.php
@@ -5,6 +5,7 @@ namespace Konnco\FilamentSafelyDelete\Pages\Actions;
 use Closure;
 use Filament\Forms\Components\TextInput;
 use Illuminate\Database\Eloquent\Model;
+use Illuminate\Support\Facades\App;
 use Konnco\FilamentSafelyDelete\Concerns\HasFieldConfirmation;
 
 class DeleteAction extends \Filament\Pages\Actions\DeleteAction
@@ -14,6 +15,10 @@ class DeleteAction extends \Filament\Pages\Actions\DeleteAction
     protected function setUp(): void
     {
         parent::setUp();
+        
+        if (App::environment('testing')) {
+            return;
+        }
 
         $this->form([
             TextInput::make('name')

--- a/src/Tables/Actions/DeleteAction.php
+++ b/src/Tables/Actions/DeleteAction.php
@@ -5,6 +5,7 @@ namespace Konnco\FilamentSafelyDelete\Tables\Actions;
 use Closure;
 use Filament\Forms\Components\TextInput;
 use Illuminate\Database\Eloquent\Model;
+use Illuminate\Support\Facades\App;
 use Konnco\FilamentSafelyDelete\Concerns\HasFieldConfirmation;
 
 class DeleteAction extends \Filament\Tables\Actions\DeleteAction
@@ -14,6 +15,10 @@ class DeleteAction extends \Filament\Tables\Actions\DeleteAction
     protected function setUp(): void
     {
         parent::setUp();
+
+        if (App::environment('testing')) {
+            return;
+        }
 
         $this->form([
             TextInput::make('name')


### PR DESCRIPTION
Makes it possible to do:

```php
	livewire(EditCustomer::class, ['record' => $customer->getKey()])
		->callPageAction(DeleteAction::class);
```
in tests.